### PR TITLE
bashのビープ音が鳴らなくなるように

### DIFF
--- a/.inputrc
+++ b/.inputrc
@@ -1,0 +1,1 @@
+set bell-style none


### PR DESCRIPTION
### 概要
Bash on Ubuntu on Windowsでタブ補完とか何かしらするたびに
ビープ音が鳴ってうるさかったので、inputrcで鳴らなくするようにしたヽ(･ω･)/ｽﾞｺｰ