### PR TITLE
npmrcにmin-release-age設定を追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# 3日経過していないパッケージの解決禁止
+min-release-age=3
+
+# pnpmの場合
+# pnpm config set --location=global minimumReleaseAge 4320


### PR DESCRIPTION
## Summary

- `.npmrc` に `min-release-age=3` を追加し、リリースから3日未満のパッケージの解決を禁止する
- サプライチェーン攻撃対策として、新しすぎるパッケージを自動インストールしないようにする

## Test plan

- [ ] `npm install` 実行時に3日未満のパッケージが解決されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)